### PR TITLE
fourth assignment: counting islands

### DIFF
--- a/assignment4.py
+++ b/assignment4.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+import unittest
+import numpy as np
+
+class UnionFindElement():
+
+    def __init__(self, parent):
+        self.parent = parent
+        self.rank = 0
+
+
+class UnionFind(): 
+    """
+    This is an implementation of a union-find (disjoint-set) data structure
+    where elements of UnionFindElement class are stored in a dictionary
+    """
+
+    def __init__(self):
+        self.uf_dict = {}
+
+    def make_set(self, idx):
+        self.uf_dict[idx] = UnionFindElement(idx)
+
+    def union(self, i, j):
+        """
+        If elements are from different sets, performs union and returns 1.
+        Returns 0 if both elements are members of the same set.
+        """
+        root_i = self.uf_dict[self.find(i)]
+        root_j = self.uf_dict[self.find(j)]
+        if root_i == root_j:
+            return 0
+        if root_i.rank > root_j.rank:
+            root_j.parent = root_i.parent
+        elif root_i.rank < root_j.rank:
+            root_i.parent = root_j.parent
+        else:
+            root_i.parent = root_j.parent
+            root_j.rank += 1
+        return 1
+
+    def find(self, x):
+        """ Returns a key of an element in a union-find dict """
+        while self.uf_dict[x].parent != x:
+            x = self.uf_dict[x].parent
+        return x
+
+
+class IslandMap():
+
+    def __init__(self, nrows, ncols, isl_array):
+        self.nrows = nrows
+        self.ncols = ncols
+        self.islands = isl_array
+
+    def isIsland(self, i, j):
+        if (i < 0) or (i >= self.nrows):
+            return False
+        if (j < 0) or (j >= self.ncols):
+            return False
+        return self.islands[i][j]
+
+    def countIslands(self):
+        """
+        Counts islands using a union-find data structure in an iterative way.
+        Returns an integer -- number of islands on a map
+        """
+        isls_uf = UnionFind()
+        counter = 0
+        for i in range(self.nrows):
+            for j in range(self.ncols):
+                if self.isIsland(i, j):
+                    isls_uf.make_set(i * self.ncols + j)
+                    counter += 1
+                    if self.isIsland(i-1, j):
+                        if isls_uf.union((i-1) * self.ncols + j, i * self.ncols + j):
+                            counter -= 1
+                    if self.isIsland(i, j-1):
+                        if isls_uf.union(i * self.ncols + j-1, i * self.ncols + j):
+                            counter -= 1
+        return counter
+
+    def countIslandsDFS(self, i, j, visited):
+        """ Auxiliary recursive function for countIslandsRecursive """
+        visited.add(i * self.ncols + j)
+        for d in ([0, 1], [1, 0], [0, -1], [-1, 0]):
+            new_i = i+d[0]
+            new_j = j+d[1]
+            if ((new_i * self.ncols + new_j) not in visited) and self.isIsland(new_i, new_j):
+                self.countIslandsDFS(new_i, new_j, visited)
+        return
+
+    def countIslandsRecursive(self):
+        """ 
+        Counts islands using Depth-First search in a recursive way.
+        """
+        visited = set()
+        counter = 0
+        for i in range(self.nrows):
+            for j in range(self.ncols):
+                if ((i * self.ncols + j) not in visited) and self.isIsland(i, j):
+                    counter += 1
+                    self.countIslandsDFS(i, j, visited)
+        return counter
+
+
+T = True
+F = False
+
+class TestCountIslands(unittest.TestCase):
+
+    def test_empty_case(self):
+        isl_map = [[F,F,F],[F,F,F],[F,F,F]]
+        im = IslandMap(3, 3, isl_map)
+        self.assertEqual(im.countIslands(), 0)
+        self.assertEqual(im.countIslandsRecursive(), 0)
+    
+    def test_full_case(self):
+        isl_map = [[T,T,T],[T,T,T],[T,T,T]]
+        im = IslandMap(3, 3, isl_map)
+        self.assertEqual(im.countIslands(), 1)
+        self.assertEqual(im.countIslandsRecursive(), 1)
+
+    def test_distinct_islands(self):
+        isl_map = [[T,F,F],[F,T,F],[F,F,T]]
+        im = IslandMap(3, 3, isl_map)
+        self.assertEqual(im.countIslands(), 3)
+        self.assertEqual(im.countIslandsRecursive(), 3)
+
+    def test_doughnut(self):
+        isl_map = [[T,T,T],[T,F,T],[T,T,T]]
+        im = IslandMap(3, 3, isl_map)
+        self.assertEqual(im.countIslands(), 1)
+        self.assertEqual(im.countIslandsRecursive(), 1)     
+
+    def test_complicated_form(self):
+        isl_map = [[F,F,T,F,T,T,T,T,T,T,F,F], [T,T,T,T,T,T,F,F,T,F,F,F]]
+        im = IslandMap(2, 12, isl_map)
+        self.assertEqual(im.countIslands(), 1)
+        self.assertEqual(im.countIslandsRecursive(), 1)   
+
+    def test_disjoint_complicated(self):
+        isl_map = [
+            [F,F,T,F,T,T,T,T,T,T,F,F], # rows 0 & 1 have one island
+            [T,T,T,T,T,T,F,F,T,F,F,F], 
+            [F,F,F,F,F,F,F,F,F,F,F,F], # empty line
+            [F,F,F,T,T,T,F,F,F,T,F,T], # row 3 has 3 islands
+            [F,F,F,F,F,F,F,F,F,F,F,F], # empty row
+            [T,T,T,T,T,T,T,T,T,T,T,T]] # row 5 has 1 island
+        im = IslandMap(6, 12, isl_map)
+        self.assertEqual(im.countIslands(), 5)
+        self.assertEqual(im.countIslandsRecursive(), 5)
+
+    def test_doughnut_in_doughnut(self):
+        isl_map = [
+            [T,T,T,T,T,T,T,T,T,T,T,T],
+            [T,F,F,F,F,F,F,F,F,F,F,T], 
+            [T,F,T,T,T,T,T,T,T,T,F,T],
+            [T,F,T,F,F,F,F,F,F,T,F,T],
+            [T,F,T,T,T,T,T,T,T,T,F,T],
+            [T,F,F,F,F,F,F,F,F,F,F,T], 
+            [T,T,T,T,T,T,T,T,T,T,T,T]]
+        im = IslandMap(7, 12, isl_map)
+        self.assertEqual(im.countIslands(), 2)
+        self.assertEqual(im.countIslandsRecursive(), 2)
+
+    def test_random_matrices(self):
+        for i in range(50):
+            np.random.seed(i)
+            sizes = [(5, 5), (10, 10), (20, 20)]
+            probs = [0.2, 0.5, 0.8]
+            for mat_size in sizes:
+                for prob in probs:
+                    isl_map = np.random.binomial(1, prob, size=mat_size)
+                    im = IslandMap(mat_size[0], mat_size[1], isl_map)
+                    self.assertEqual(im.countIslands(), im.countIslandsRecursive())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/assignment4.py
+++ b/assignment4.py
@@ -104,62 +104,59 @@ class IslandMap():
         return counter
 
 
-T = True
-F = False
-
 class TestCountIslands(unittest.TestCase):
 
     def test_empty_case(self):
-        isl_map = [[F,F,F],[F,F,F],[F,F,F]]
+        isl_map = [[0,0,0],[0,0,0],[0,0,0]]
         im = IslandMap(3, 3, isl_map)
         self.assertEqual(im.countIslands(), 0)
         self.assertEqual(im.countIslandsRecursive(), 0)
     
     def test_full_case(self):
-        isl_map = [[T,T,T],[T,T,T],[T,T,T]]
+        isl_map = [[1,1,1],[1,1,1],[1,1,1]]
         im = IslandMap(3, 3, isl_map)
         self.assertEqual(im.countIslands(), 1)
         self.assertEqual(im.countIslandsRecursive(), 1)
 
     def test_distinct_islands(self):
-        isl_map = [[T,F,F],[F,T,F],[F,F,T]]
+        isl_map = [[1,0,0],[0,1,0],[0,0,1]]
         im = IslandMap(3, 3, isl_map)
         self.assertEqual(im.countIslands(), 3)
         self.assertEqual(im.countIslandsRecursive(), 3)
 
     def test_doughnut(self):
-        isl_map = [[T,T,T],[T,F,T],[T,T,T]]
+        isl_map = [[1,1,1],[1,0,1],[1,1,1]]
         im = IslandMap(3, 3, isl_map)
         self.assertEqual(im.countIslands(), 1)
         self.assertEqual(im.countIslandsRecursive(), 1)     
 
     def test_complicated_form(self):
-        isl_map = [[F,F,T,F,T,T,T,T,T,T,F,F], [T,T,T,T,T,T,F,F,T,F,F,F]]
+        isl_map = [[0,0,1,0,1,1,1,1,1,1,0,0], [1,1,1,1,1,1,0,0,1,0,0,0]]
         im = IslandMap(2, 12, isl_map)
         self.assertEqual(im.countIslands(), 1)
         self.assertEqual(im.countIslandsRecursive(), 1)   
 
     def test_disjoint_complicated(self):
         isl_map = [
-            [F,F,T,F,T,T,T,T,T,T,F,F], # rows 0 & 1 have one island
-            [T,T,T,T,T,T,F,F,T,F,F,F], 
-            [F,F,F,F,F,F,F,F,F,F,F,F], # empty line
-            [F,F,F,T,T,T,F,F,F,T,F,T], # row 3 has 3 islands
-            [F,F,F,F,F,F,F,F,F,F,F,F], # empty row
-            [T,T,T,T,T,T,T,T,T,T,T,T]] # row 5 has 1 island
+            [0,0,1,0,1,1,1,1,1,1,0,0], # rows 0 & 1 have one island
+            [1,1,1,1,1,1,0,0,1,0,0,0], 
+            [0,0,0,0,0,0,0,0,0,0,0,0], # empty line
+            [0,0,0,1,1,1,0,0,0,1,0,1], # row 3 has 3 islands
+            [0,0,0,0,0,0,0,0,0,0,0,0], # empty row
+            [1,1,1,1,1,1,1,1,1,1,1,1]] # row 5 has 1 island
         im = IslandMap(6, 12, isl_map)
         self.assertEqual(im.countIslands(), 5)
         self.assertEqual(im.countIslandsRecursive(), 5)
 
     def test_doughnut_in_doughnut(self):
         isl_map = [
-            [T,T,T,T,T,T,T,T,T,T,T,T],
-            [T,F,F,F,F,F,F,F,F,F,F,T], 
-            [T,F,T,T,T,T,T,T,T,T,F,T],
-            [T,F,T,F,F,F,F,F,F,T,F,T],
-            [T,F,T,T,T,T,T,T,T,T,F,T],
-            [T,F,F,F,F,F,F,F,F,F,F,T], 
-            [T,T,T,T,T,T,T,T,T,T,T,T]]
+            [1,1,1,1,1,1,1,1,1,1,1,1],
+            [1,0,0,0,0,0,0,0,0,0,0,1], 
+            [1,0,1,1,1,1,1,1,1,1,0,1],
+            [1,0,1,0,0,0,0,0,0,1,0,1],
+            [1,0,1,1,1,1,1,1,1,1,0,1],
+            [1,0,0,0,0,0,0,0,0,0,0,1], 
+            [1,1,1,1,1,1,1,1,1,1,1,1]]
         im = IslandMap(7, 12, isl_map)
         self.assertEqual(im.countIslands(), 2)
         self.assertEqual(im.countIslandsRecursive(), 2)


### PR DESCRIPTION
## Task 4, assignment4.py

**Note**: 
I used NumPy library for testing. And easy way to install it is using pip:`pip install numpy`
If you would not like to install Numpy please comment out lines 3 and 167 to 176.

**Description:**
In this task we should implement an algorithm that counts the number of islands on a given 2-dimensional map of Booleans (True for pieces that belong to islands, False for others). An island are pieces of land joined vertically or horizontally, not diagonally.

### Solution 1
The easiest way to solve the problem is by using **DFS**. We just iterate over the map and run DFS from each not visited element that belongs to an island. Thus on each DFS run we mark all the island cells and increment the counter by 1.
The main problem is the recursion stack -- when testing by generating random boolean matrices of large size python threw an error 'maximum recursion depth exceeded'

### Solution 2
Another option is to use a **union-find** data structure. In this case the elements are stored in a python dictionary: the key is a `i * ncols + j` value identifying an element of an array, the value is a data structure that stores a parent and a rank. The disjoint sets are in fact trees, and 'union' operation adds one tree under the root of another one, using the rank value for keeping it balanced.

### Comparison and other thoughts
I also tried implementing it without a union-find data structure, but in an iterative way, just storing information of islands element of a previous row. It is possible though requires a lot of if-else clauses and other operations. The code loses clarity and readability, but in this case the storage might be reduced to O(min(nrows, ncols)) worst case.

In case of recursive approach we have O(nrows * ncols) for iterating over the array plus O(nrows * ncols) for the DFS itself as we visit each cell at most once. But we also have to keep track of all visited cells and some storage is required for recursive calls (maximum nrows * ncols calls), then it's O(nrows * ncols) storage.

In case of union-find the time complexity is worse because we need to perform Find and Union operations in addition to iterating over the array, but there are different heuristics like adding by rank to improve the time. It is also O(nrows * ncols) in space since we might store data for all of the island cells.

_To be completely honest in this task I am not very confident in discussing one approach against another one: I see that recursion requires storing data on each call and there is such thing as maximum recursion depth, but is it so critical that we prefer using union-find with worse asymptotics? Did I use UnionFind in a right way? Didn't my logic fail?_